### PR TITLE
fix: resolve blank screen issue after content generation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -161,12 +161,9 @@ const App: React.FC = () => {
       case 'editor':
         return (
           <EditorPage
-            slides={slides}
-            settings={settings}
-            onUpdateSlideText={handleUpdateSlideText}
-            onSettingsChange={handleSettingsChange}
-            onCreateNew={handleCreateNew}
-            onRegenerateImage={handleRegenerateImage}
+            initialSlides={slides}
+            initialSettings={settings}
+            onBack={handleCreateNew}
           />
         );
       case 'home':


### PR DESCRIPTION
This commit fixes a bug where the application would show a blank screen after the content generation process was complete.

The issue was caused by a mismatch between the props expected by the `EditorPage` component and the props being passed to it from the `App.tsx` component.

I have updated the `App.tsx` file to pass the correct props (`initialSlides`, `initialSettings`, and `onBack`) to the `EditorPage` component, which resolves the issue.